### PR TITLE
feat: expose phoenixd v0.9 swap-in address

### DIFF
--- a/backend/src/routes/phoenixd.test.ts
+++ b/backend/src/routes/phoenixd.test.ts
@@ -7,6 +7,7 @@ const {
   mockCreateInvoice,
   mockCreateOffer,
   mockGetLnAddress,
+  mockGetSwapInAddress,
   mockPayInvoice,
   mockPayOffer,
   mockPayLnAddress,
@@ -19,6 +20,7 @@ const {
   mockCreateInvoice: vi.fn(),
   mockCreateOffer: vi.fn(),
   mockGetLnAddress: vi.fn(),
+  mockGetSwapInAddress: vi.fn(),
   mockPayInvoice: vi.fn(),
   mockPayOffer: vi.fn(),
   mockPayLnAddress: vi.fn(),
@@ -41,6 +43,7 @@ vi.mock('../index.js', () => ({
     createInvoice: mockCreateInvoice,
     createOffer: mockCreateOffer,
     getLnAddress: mockGetLnAddress,
+    getSwapInAddress: mockGetSwapInAddress,
     payInvoice: mockPayInvoice,
     payOffer: mockPayOffer,
     payLnAddress: mockPayLnAddress,
@@ -58,6 +61,7 @@ const mockPhoenixd = {
   createInvoice: mockCreateInvoice,
   createOffer: mockCreateOffer,
   getLnAddress: mockGetLnAddress,
+  getSwapInAddress: mockGetSwapInAddress,
   payInvoice: mockPayInvoice,
   payOffer: mockPayOffer,
   payLnAddress: mockPayLnAddress,
@@ -194,6 +198,20 @@ describe('Phoenixd Routes', () => {
       const response = await request(app).get('/api/phoenixd/getlnaddress');
 
       expect(response.status).toBe(500);
+    });
+  });
+
+  describe('GET /getswapinaddress', () => {
+    it('should return the current swap-in address', async () => {
+      mockPhoenixd.getSwapInAddress.mockResolvedValueOnce({
+        address: 'bc1qswapin',
+        index: 7,
+      });
+
+      const response = await request(app).get('/api/phoenixd/getswapinaddress');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ address: 'bc1qswapin', index: 7 });
     });
   });
 

--- a/backend/src/routes/phoenixd.ts
+++ b/backend/src/routes/phoenixd.ts
@@ -64,6 +64,21 @@ phoenixdRouter.get(
   }
 );
 
+// Get current on-chain swap-in deposit address (phoenixd v0.9+)
+phoenixdRouter.get(
+  '/getswapinaddress',
+  requireAuth,
+  async (_req: AuthenticatedRequest, res: Response) => {
+    try {
+      const result = await phoenixd.getSwapInAddress();
+      res.json(result);
+    } catch (error) {
+      console.error('Error getting swap-in address:', error);
+      res.status(500).json({ error: (error as Error).message });
+    }
+  }
+);
+
 // Pay Bolt11 Invoice
 phoenixdRouter.post(
   '/payinvoice',

--- a/backend/src/services/phoenixd.test.ts
+++ b/backend/src/services/phoenixd.test.ts
@@ -121,6 +121,24 @@ describe('PhoenixdService', () => {
       });
     });
 
+    describe('getSwapInAddress', () => {
+      it('should return the current swap-in address', async () => {
+        const mockResponse = { address: 'bc1qswapin', index: 7 };
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          headers: { get: () => 'application/json' },
+          json: () => Promise.resolve(mockResponse),
+        });
+
+        await expect(service.getSwapInAddress()).resolves.toEqual(mockResponse);
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/getswapinaddress'),
+          expect.objectContaining({ method: 'GET' })
+        );
+      });
+    });
+
     describe('listChannels', () => {
       it('should return empty array when no channels', async () => {
         // listChannels now calls getInfo internally

--- a/backend/src/services/phoenixd.ts
+++ b/backend/src/services/phoenixd.ts
@@ -172,7 +172,16 @@ export class PhoenixdService {
     return this.request<{
       balanceSat: number;
       feeCreditSat: number;
+      swapIn?: {
+        unconfirmedBalanceSat: number;
+        weaklyConfirmedBalanceSat: number;
+        deeplyConfirmedBalanceSat: number;
+      } | null;
     }>('GET', '/getbalance');
+  }
+
+  async getSwapInAddress() {
+    return this.request<{ address: string; index: number }>('GET', '/getswapinaddress');
   }
 
   async listChannels() {


### PR DESCRIPTION
## Summary
- add typed phoenixd v0.9 swap-in balance fields
- expose `GET /api/phoenixd/getswapinaddress` through the authenticated dashboard backend
- cover the service adapter and route with regression tests

## Upstream compatibility
phoenixd v0.9.0 added `GET /getswapinaddress` and the `swapIn` object on `GET /getbalance`:
https://github.com/ACINQ/phoenixd/blob/v0.9.0/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt

## Verification
- 415 unit tests passed (257 frontend, 158 backend)
- 237 Cypress E2E tests passed
- formatting and ESLint passed
- backend and production frontend builds passed
- `git diff --check` passed